### PR TITLE
Site Logo now inverts colors when switching themes across site

### DIFF
--- a/frontend/src/app/Home.module.css
+++ b/frontend/src/app/Home.module.css
@@ -14,8 +14,7 @@
 }
 
 .logo {
-    font-size: 24px;
-    font-weight: bold;
+    filter: var(--logo-bw);
 }
 
 .navList {

--- a/frontend/src/app/LoginRedirect/LoginRedirect.module.css
+++ b/frontend/src/app/LoginRedirect/LoginRedirect.module.css
@@ -14,8 +14,7 @@
 }
 
 .logo {
-    font-size: 24px;
-    font-weight: bold;
+    filter: var(--logo-bw);
 }
 
 .navList {

--- a/frontend/src/app/LoginRedirect/page.jsx
+++ b/frontend/src/app/LoginRedirect/page.jsx
@@ -12,7 +12,7 @@ const LoginRedirect = () => {
     <div className={styles.container}>
       <header className={styles.header}>
         <div className={styles.navContainer}>
-          <img src='BRLogo.png' width={300} />
+          <img className={styles.logo} src='BRLogo.png' width={300} />
           <nav>
             <ul className={styles.navList}>
               <li>

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -10,6 +10,7 @@
   --danger: #ff4d4d;
   --danger-secondary: #cc0000;
   --text-bw: #000000;
+  --logo-bw: invert(100%);
 }
 
 .dark {
@@ -24,6 +25,7 @@
   --danger: #ff4d4d;
   --danger-secondary: #cc0000;
   --text-bw: #ffffff;
+  --logo-bw: invert(0%);
 }
 
 body {

--- a/frontend/src/app/page.jsx
+++ b/frontend/src/app/page.jsx
@@ -39,7 +39,7 @@ const LandingPage = () => {
       <div className={styles.container}>
         <header className={styles.header}>
           <div className={styles.navContainer}>
-            <img src='BRLogo.png' width={250} />
+            <img className={styles.logo} src='BRLogo.png' width={250} />
             <nav>
               <ul className={styles.navList}>
                 <li>

--- a/frontend/src/components/Navbar/Navbar.jsx
+++ b/frontend/src/components/Navbar/Navbar.jsx
@@ -62,7 +62,7 @@ export function Navbar() {
   return (
     <div className={styles.container}>
       <Link className={theme === 1 ? styles.logo : styles.logoDark} href='/Dashboard'>
-        <img src='BRLogo.png' width={250} />
+        <img className={styles.logo} src='BRLogo.png' width={250} />
       </Link>
 
       <div className={styles.nav_options}>

--- a/frontend/src/components/Navbar/Navbar.module.css
+++ b/frontend/src/components/Navbar/Navbar.module.css
@@ -16,7 +16,11 @@
   gap: 16px;
 }
 
-.logo, .links {
+.logo {
+  filter: var(--logo-bw);
+}
+
+.links {
   display: flex;
   justify-content: center;
   align-items: center;


### PR DESCRIPTION
Added a filter to the globals.css and implemented it across the site so that the BoilerRoom logo inverts colors when themes are switched, making it visible in lightmode